### PR TITLE
DT-727 common dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,14 @@ orbs:
   dps: ministryofjustice/dps@1.2.1
   owasp: entur/owasp@0.0.10
 
+executors:
+  validator:
+    docker:
+      - image: circleci/openjdk:11-jdk
+    environment:
+      _JAVA_OPTIONS: -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-XX:+UseContainerSupport
+    working_directory: ~/app
+
 jobs:
   validate:
     executor: dps/java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   dps: ministryofjustice/dps@1.2.1
+  owasp: entur/owasp@0.0.10
 
 jobs:
   validate:
@@ -36,3 +37,15 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+
+  scheduled:
+    triggers:
+      - schedule:
+          cron: "0 7 * * 1-5"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - owasp/gradle_owasp_dependency_check:
+          executor: validator

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   id("maven-publish")
   id("com.github.ben-manes.versions") version "0.28.0"
   id("se.patrikerdes.use-latest-versions") version "0.2.13"
+  id("org.owasp.dependencycheck") version "5.3.2.1"
 }
 
 repositories {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -43,7 +43,6 @@ class DpsSpringBootPlugin : Plugin<Project> {
     addDependencyCheckSuppressionFile(project)
     rejectUnstableDependencyUpdates(project)
     setKotlinCompileJvmVersion(project)
-    excludeJunit4(project)
 
     addDependencies(project)
 
@@ -179,10 +178,6 @@ class DpsSpringBootPlugin : Plugin<Project> {
       it.into("${project.buildDir}/libs")
     }
     project.tasks.getByName("assemble").dependsOn(copyAgentTask)
-  }
-
-  private fun excludeJunit4(project: Project) {
-    project.configurations.getByName("testImplementation").exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))
   }
 
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -98,6 +98,10 @@ class DpsSpringBootPlugin : Plugin<Project> {
     project.dependencies.add("implementation", "io.springfox:springfox-swagger-ui:2.9.2")
     project.dependencies.add("implementation", "io.springfox:springfox-bean-validators:2.9.2")
 
+    project.dependencies.add("implementation", "net.logstash.logback:logstash-logback-encoder:6.3")
+    project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.0")
+    project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-logging-logback:2.6.0")
+
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -102,8 +102,12 @@ class DpsSpringBootPlugin : Plugin<Project> {
     project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.0")
     project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-logging-logback:2.6.0")
 
+    project.dependencies.add("implementation", "com.github.timpeeters:spring-boot-graceful-shutdown:2.2.1")
+    project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin")
+
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))
+    project.dependencies.add("testImplementation", "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
 
     project.dependencies.add("agentDeps", "com.microsoft.azure:applicationinsights-agent:2.6.0")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -43,6 +43,7 @@ class DpsSpringBootPlugin : Plugin<Project> {
     addDependencyCheckSuppressionFile(project)
     rejectUnstableDependencyUpdates(project)
     setKotlinCompileJvmVersion(project)
+    excludeJunit4(project)
 
     addDependencies(project)
 
@@ -178,6 +179,10 @@ class DpsSpringBootPlugin : Plugin<Project> {
       it.into("${project.buildDir}/libs")
     }
     project.tasks.getByName("assemble").dependsOn(copyAgentTask)
+  }
+
+  private fun excludeJunit4(project: Project) {
+    project.configurations.getByName("testImplementation").exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))
   }
 
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -100,7 +100,7 @@ class DpsSpringBootPlugin : Plugin<Project> {
 
     project.dependencies.add("implementation", "com.github.timpeeters:spring-boot-graceful-shutdown:2.2.1")
     project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin")
-    project.dependencies.add("implementation", "com.google.guava:guava:29.0-jre)") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
+    project.dependencies.add("implementation", "com.google.guava:guava:29.0-jre") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
 
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -94,6 +94,10 @@ class DpsSpringBootPlugin : Plugin<Project> {
     project.dependencies.add("implementation", "org.springframework.boot:spring-boot-starter-web")
     project.dependencies.add("implementation", "org.springframework.boot:spring-boot-starter-actuator")
 
+    project.dependencies.add("implementation", "io.springfox:springfox-swagger2:2.9.2")
+    project.dependencies.add("implementation", "io.springfox:springfox-swagger-ui:2.9.2")
+    project.dependencies.add("implementation", "io.springfox:springfox-bean-validators:2.9.2")
+
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -100,7 +100,7 @@ class DpsSpringBootPlugin : Plugin<Project> {
 
     project.dependencies.add("implementation", "com.github.timpeeters:spring-boot-graceful-shutdown:2.2.1")
     project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin")
-    project.dependencies.add("implementation", "com.google.guava:guava:28.2-jre)") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
+    project.dependencies.add("implementation", "com.google.guava:guava:29.0-jre)") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
 
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -94,10 +94,6 @@ class DpsSpringBootPlugin : Plugin<Project> {
     project.dependencies.add("implementation", "org.springframework.boot:spring-boot-starter-web")
     project.dependencies.add("implementation", "org.springframework.boot:spring-boot-starter-actuator")
 
-    project.dependencies.add("implementation", "io.springfox:springfox-swagger2:2.9.2")
-    project.dependencies.add("implementation", "io.springfox:springfox-swagger-ui:2.9.2")
-    project.dependencies.add("implementation", "io.springfox:springfox-bean-validators:2.9.2")
-
     project.dependencies.add("implementation", "net.logstash.logback:logstash-logback-encoder:6.3")
     project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.0")
     project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-logging-logback:2.6.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -104,6 +104,7 @@ class DpsSpringBootPlugin : Plugin<Project> {
 
     project.dependencies.add("implementation", "com.github.timpeeters:spring-boot-graceful-shutdown:2.2.1")
     project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin")
+    project.dependencies.add("implementation", "com.google.guava:guava:28.2-jre)")
 
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -104,7 +104,7 @@ class DpsSpringBootPlugin : Plugin<Project> {
 
     project.dependencies.add("implementation", "com.github.timpeeters:spring-boot-graceful-shutdown:2.2.1")
     project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin")
-    project.dependencies.add("implementation", "com.google.guava:guava:28.2-jre)")
+    project.dependencies.add("implementation", "com.google.guava:guava:28.2-jre)") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
 
     val springBootTest = project.dependencies.add("testImplementation", "org.springframework.boot:spring-boot-starter-test") as ExternalModuleDependency
     springBootTest.exclude(mapOf("group" to "org.junit.vintage", "module" to "junit-vintage-engine"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -138,7 +138,8 @@ class DpsSpringBootPluginTest {
           .extracting("group", "name", "version")
           .contains(
               Tuple.tuple("com.github.timpeeters", "spring-boot-graceful-shutdown", "2.2.1"),
-              Tuple.tuple("com.fasterxml.jackson.module", "jackson-module-kotlin", null)
+              Tuple.tuple("com.fasterxml.jackson.module", "jackson-module-kotlin", null),
+              Tuple.tuple("com.google.guava", "guava", "28.2-jre")
           )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -127,7 +127,7 @@ class DpsSpringBootPluginTest {
           .contains(
               Tuple.tuple("com.github.timpeeters", "spring-boot-graceful-shutdown", "2.2.1"),
               Tuple.tuple("com.fasterxml.jackson.module", "jackson-module-kotlin", null),
-              Tuple.tuple("com.google.guava", "guava", "28.2-jre")
+              Tuple.tuple("com.google.guava", "guava", "29.0-jre")
           )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -139,7 +139,7 @@ class DpsSpringBootPluginTest {
           .contains(
               Tuple.tuple("com.github.timpeeters", "spring-boot-graceful-shutdown", "2.2.1"),
               Tuple.tuple("com.fasterxml.jackson.module", "jackson-module-kotlin", null),
-              Tuple.tuple("com.google.guava", "guava", "28.2-jre") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
+              Tuple.tuple("com.google.guava", "guava", "28.2-jre")
           )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -139,7 +139,7 @@ class DpsSpringBootPluginTest {
           .contains(
               Tuple.tuple("com.github.timpeeters", "spring-boot-graceful-shutdown", "2.2.1"),
               Tuple.tuple("com.fasterxml.jackson.module", "jackson-module-kotlin", null),
-              Tuple.tuple("com.google.guava", "guava", "28.2-jre")
+              Tuple.tuple("com.google.guava", "guava", "28.2-jre") // This is only required because the version pulled in a as transitive dependency has CVE vulnerabilities
           )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -118,6 +118,18 @@ class DpsSpringBootPluginTest {
               Tuple.tuple("io.springfox", "springfox-swagger-ui", "2.9.2"),
               Tuple.tuple("io.springfox", "springfox-bean-validators", "2.9.2")
           )
+
+      @Test
+      fun `Should apply logging libraries`() {
+        assertThat(project.configurations.getByName("implementation").dependencies)
+            .extracting("group", "name", "version")
+            .contains(
+                Tuple.tuple("net.logstash.logback", "logstash-logback-encoder", "6.3"),
+                Tuple.tuple("com.microsoft.azure", "applicationinsights-spring-boot-starter", "2.6.0"),
+                Tuple.tuple("com.microsoft.azure", "applicationinsights-logging-logback", "2.6.0")
+            )
+      }
+
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -110,6 +110,17 @@ class DpsSpringBootPluginTest {
     }
 
     @Test
+    fun `Should apply springfox libraries`() {
+      assertThat(project.configurations.getByName("implementation").dependencies)
+          .extracting("group", "name", "version")
+          .contains(
+              Tuple.tuple("io.springfox", "springfox-swagger2", "2.9.2"),
+              Tuple.tuple("io.springfox", "springfox-swagger-ui", "2.9.2"),
+              Tuple.tuple("io.springfox", "springfox-bean-validators", "2.9.2")
+          )
+    }
+
+    @Test
     fun `Should apply Spring Boot Test`() {
       assertThat(project.configurations.getByName("testImplementation").dependencies)
           .extracting("group", "name")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -133,11 +133,22 @@ class DpsSpringBootPluginTest {
     }
 
     @Test
-    fun `Should apply Spring Boot Test`() {
-      assertThat(project.configurations.getByName("testImplementation").dependencies)
-          .extracting("group", "name")
+    fun `Should apply miscellaneous dependencies`() {
+      assertThat(project.configurations.getByName("implementation").dependencies)
+          .extracting("group", "name", "version")
           .contains(
-              Tuple.tuple("org.springframework.boot", "spring-boot-starter-test")
+              Tuple.tuple("com.github.timpeeters", "spring-boot-graceful-shutdown", "2.2.1"),
+              Tuple.tuple("com.fasterxml.jackson.module", "jackson-module-kotlin", null)
+          )
+    }
+
+    @Test
+    fun `Should apply Test Dependencies`() {
+      assertThat(project.configurations.getByName("testImplementation").dependencies)
+          .extracting("group", "name", "version")
+          .contains(
+              Tuple.tuple("org.springframework.boot", "spring-boot-starter-test", null),
+              Tuple.tuple("com.nhaarman.mockitokotlin2", "mockito-kotlin", "2.2.0")
           )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPluginTest.kt
@@ -110,26 +110,14 @@ class DpsSpringBootPluginTest {
     }
 
     @Test
-    fun `Should apply springfox libraries`() {
+    fun `Should apply logging libraries`() {
       assertThat(project.configurations.getByName("implementation").dependencies)
           .extracting("group", "name", "version")
           .contains(
-              Tuple.tuple("io.springfox", "springfox-swagger2", "2.9.2"),
-              Tuple.tuple("io.springfox", "springfox-swagger-ui", "2.9.2"),
-              Tuple.tuple("io.springfox", "springfox-bean-validators", "2.9.2")
+              Tuple.tuple("net.logstash.logback", "logstash-logback-encoder", "6.3"),
+              Tuple.tuple("com.microsoft.azure", "applicationinsights-spring-boot-starter", "2.6.0"),
+              Tuple.tuple("com.microsoft.azure", "applicationinsights-logging-logback", "2.6.0")
           )
-
-      @Test
-      fun `Should apply logging libraries`() {
-        assertThat(project.configurations.getByName("implementation").dependencies)
-            .extracting("group", "name", "version")
-            .contains(
-                Tuple.tuple("net.logstash.logback", "logstash-logback-encoder", "6.3"),
-                Tuple.tuple("com.microsoft.azure", "applicationinsights-spring-boot-starter", "2.6.0"),
-                Tuple.tuple("com.microsoft.azure", "applicationinsights-logging-logback", "2.6.0")
-            )
-      }
-
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/JavaRunFuncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/JavaRunFuncTest.kt
@@ -50,6 +50,12 @@ class JavaRunFuncTest {
     assertThatJson(infoResponse).node("git.branch").isEqualTo("master")
   }
 
+  // The fact the URL request didn't throw an exception indicates the app is serving up swagger docs
+  @Test
+  fun `Swagger documentation UI should be available`() {
+    URL("http://localhost:8080/swagger-ui.html").readText()
+  }
+
 }
 
 fun javaProjectDetails(projectDir: File) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/JavaRunFuncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/JavaRunFuncTest.kt
@@ -50,12 +50,6 @@ class JavaRunFuncTest {
     assertThatJson(infoResponse).node("git.branch").isEqualTo("master")
   }
 
-  // The fact the URL request didn't throw an exception indicates the app is serving up swagger docs
-  @Test
-  fun `Swagger documentation UI should be available`() {
-    URL("http://localhost:8080/swagger-ui.html").readText()
-  }
-
 }
 
 fun javaProjectDetails(projectDir: File) =


### PR DESCRIPTION
Adds dependencies that will be needed by ALL Spring Boot projects (note this is up for debate!), and also schedules the OWASP dependency check.