### PR TITLE
DT-1063 update to fail if CVE's detected.  Dependency check was not failing the build.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.owasp.dependencycheck.reporting.ReportGenerator.Format.ALL
 
 plugins {
   kotlin("jvm") version "1.3.72"
@@ -87,4 +88,10 @@ tasks {
       isNonStable(candidate.version) && !isNonStable(currentVersion)
     }
   }
+}
+
+dependencyCheck {
+  failBuildOnCVSS = 5F
+  format = ALL
+  analyzers.assemblyEnabled = false
 }


### PR DESCRIPTION
Circle job never failed even if CVE's detected as level was defaulting to 11 which basically means never fail.