### PR TITLE
DT-1066 suppressing the kotlin CVEs for projects that use the plugin as there is no immediate/easy fix.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ fun isNonStable(version: String): Boolean {
 
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "0.4.7"
+version = "0.4.8"
 
 gradlePlugin {
   plugins {
@@ -57,7 +57,7 @@ dependencies {
 
   implementation("org.springframework.boot:spring-boot-gradle-plugin:2.3.2.RELEASE")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
-  implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.9.RELEASE")
+  implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.10.RELEASE")
   implementation("org.owasp:dependency-check-gradle:5.3.2.1")
   implementation("com.github.ben-manes:gradle-versions-plugin:0.29.0")
   implementation("com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.2.3")
@@ -65,7 +65,7 @@ dependencies {
   implementation("se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin:0.2.14")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
-  testImplementation("org.mockito:mockito-junit-jupiter:3.4.4")
+  testImplementation("org.mockito:mockito-junit-jupiter:3.4.6")
   testImplementation("org.assertj:assertj-core:3.16.1")
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.18.1")
   testImplementation("com.google.code.gson:gson:2.8.6")
@@ -88,10 +88,4 @@ tasks {
       isNonStable(candidate.version) && !isNonStable(currentVersion)
     }
   }
-}
-
-dependencyCheck {
-  failBuildOnCVSS = 5F
-  format = ALL
-  analyzers.assemblyEnabled = false
 }

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -54,4 +54,131 @@
     </packageUrl>
     <cve>CVE-2018-1258</cve>
   </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-compiler-embeddable-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-compiler\-embeddable@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-daemon-embeddable-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-daemon\-embeddable@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-reflect-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-reflect@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-script-runtime-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-script\-runtime@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-scripting-common-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-scripting\-common@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-scripting-compiler-embeddable-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-scripting\-compiler\-embeddable@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-scripting-compiler-impl-embeddable-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-scripting\-compiler\-impl\-embeddable@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-scripting-jvm-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-scripting\-jvm@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-stdlib-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-stdlib-common-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-common@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-stdlib-jdk7-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-jdk7@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-stdlib-jdk8-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-jdk8@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-allopen-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-allopen@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-gradle-plugin-api-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-gradle\-plugin\-api@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-gradle-plugin-model-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-gradle\-plugin\-model@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-native-utils-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-native\-utils@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-noarg-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-noarg@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: kotlin-util-io-1.3.72.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-util\-io@.*$</packageUrl>
+    <cve>CVE-2020-15824</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
I have tested this against two projects prison-api and keyworker-api to make sure the `./gradlew dependencyCheckAnalyze` passes.

Also updated to later libs where available.