### PR TITLE
DT-1069 no kotlin bespoke properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ plugins {
 ```
 Where the `plugin-version` can be found by going to https://plugins.gradle.org/plugin/uk.gov.justice.hmpps.gradle-spring-boot
 
+### Plugin Configuration
+It is now possible to control which 3rd party plugins are applied by this plugin.
+
+In your project you can add the following properties to a file called dps-gradle-spring-boot.properties in `key=value` pairs.
+
+| Property Name | Default Value | Description |
+| ------------- | ------------- | ----------- |
+| kotlinProject | true          | Decides whether to apply the Koktlin plugin or the Java plugin | 
+
+
 ### Duplicated build logic
 
 This plugin provides various build logic that may already exist in your project, and using this plugin may:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "1.0.5"
+version = "1.0.6"
 
 gradlePlugin {
   plugins {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import uk.gov.justice.digital.hmpps.gradle.ProjectProperties.IS_KOTLIN_PROJECT
 import uk.gov.justice.digital.hmpps.gradle.configmanagers.AppInsightsConfigManager
 import uk.gov.justice.digital.hmpps.gradle.configmanagers.BaseConfigManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.DependencyCheckPluginManager
@@ -14,18 +13,12 @@ import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.SpringBootPluginManage
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.TestLoggerPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.UseLatestVersionsPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.VersionsPluginManager
-import java.io.FileInputStream
-import java.util.Properties
-
-enum class ProjectProperties(val key: String, val defaultValue: Any) {
-  IS_KOTLIN_PROJECT("kotlinProject", true)
-}
 
 class DpsSpringBootPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
 
-    loadProperties(project)
+    loadPluginProperties(project)
 
     val configManagers = configManagers(project)
 
@@ -34,14 +27,6 @@ class DpsSpringBootPlugin : Plugin<Project> {
     project.afterEvaluate {
       configManagers.forEach { it.afterEvaluate() }
     }
-  }
-
-  private fun loadProperties(project: Project) {
-    val properties = Properties()
-    try { properties.load(FileInputStream(project.file("gradle.properties"))) }
-    catch (ex: Exception) { project.logger.info("No gradle.properties file found, using defaults")}
-
-    project.extensions.extraProperties[IS_KOTLIN_PROJECT.name] = properties.getProperty(IS_KOTLIN_PROJECT.name)?.equals("true") ?: IS_KOTLIN_PROJECT.defaultValue
   }
 
   private fun configManagers(project: Project): List<ConfigManager> {
@@ -56,7 +41,7 @@ class DpsSpringBootPlugin : Plugin<Project> {
         PluginManager.from(::UseLatestVersionsPluginManager, project),
         PluginManager.from(::TestLoggerPluginManager, project)
     )
-    if (project.extensions.extraProperties[IS_KOTLIN_PROJECT.name] as Boolean) {
+    if (project.kotlinProject()) {
       managers.add(PluginManager.from(::KotlinPluginManager, project))
     } else {
       managers.add(PluginManager.from(::JavaPluginManager, project))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/DpsSpringBootPlugin.kt
@@ -2,20 +2,30 @@ package uk.gov.justice.digital.hmpps.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import uk.gov.justice.digital.hmpps.gradle.ProjectProperties.IS_KOTLIN_PROJECT
 import uk.gov.justice.digital.hmpps.gradle.configmanagers.AppInsightsConfigManager
 import uk.gov.justice.digital.hmpps.gradle.configmanagers.BaseConfigManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.DependencyCheckPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.DependencyManagementPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.GitPropertiesPluginManager
+import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.JavaPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.KotlinPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.SpringBootPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.TestLoggerPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.UseLatestVersionsPluginManager
 import uk.gov.justice.digital.hmpps.gradle.pluginmanagers.VersionsPluginManager
+import java.io.FileInputStream
+import java.util.Properties
+
+enum class ProjectProperties(val key: String, val defaultValue: Any) {
+  IS_KOTLIN_PROJECT("kotlinProject", true)
+}
 
 class DpsSpringBootPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
+
+    loadProperties(project)
 
     val configManagers = configManagers(project)
 
@@ -26,12 +36,19 @@ class DpsSpringBootPlugin : Plugin<Project> {
     }
   }
 
+  private fun loadProperties(project: Project) {
+    val properties = Properties()
+    try { properties.load(FileInputStream(project.file("gradle.properties"))) }
+    catch (ex: Exception) { project.logger.info("No gradle.properties file found, using defaults")}
+
+    project.extensions.extraProperties[IS_KOTLIN_PROJECT.name] = properties.getProperty(IS_KOTLIN_PROJECT.name)?.equals("true") ?: IS_KOTLIN_PROJECT.defaultValue
+  }
+
   private fun configManagers(project: Project): List<ConfigManager> {
-    return listOf(
+    val managers = mutableListOf(
         BaseConfigManager(project),
         AppInsightsConfigManager(project),
         PluginManager.from(::SpringBootPluginManager, project),
-        PluginManager.from(::KotlinPluginManager, project),
         PluginManager.from(::DependencyManagementPluginManager, project),
         PluginManager.from(::DependencyCheckPluginManager, project),
         PluginManager.from(::VersionsPluginManager, project),
@@ -39,6 +56,11 @@ class DpsSpringBootPlugin : Plugin<Project> {
         PluginManager.from(::UseLatestVersionsPluginManager, project),
         PluginManager.from(::TestLoggerPluginManager, project)
     )
+    if (project.extensions.extraProperties[IS_KOTLIN_PROJECT.name] as Boolean) {
+      managers.add(PluginManager.from(::KotlinPluginManager, project))
+    } else {
+      managers.add(PluginManager.from(::JavaPluginManager, project))
+    }
+    return managers.toList()
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PluginProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PluginProperties.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+import org.gradle.api.Project
+import uk.gov.justice.digital.hmpps.gradle.PluginProperty.IS_KOTLIN_PROJECT
+import java.io.FileInputStream
+import java.util.Properties
+
+internal enum class PluginProperty(val key: String, val defaultValue: Any) {
+  IS_KOTLIN_PROJECT("kotlinProject", true)
+}
+
+internal const val PROJECT_PROPERTY_FILE = "dps-gradle-spring-boot.properties"
+
+internal fun loadPluginProperties(project: Project) {
+  val properties = Properties()
+  try { properties.load(FileInputStream(project.file(PROJECT_PROPERTY_FILE))) }
+  catch (ex: Exception) { project.logger.info("No $PROJECT_PROPERTY_FILE file found, using defaults")}
+
+  project.kotlinProject(properties.getBooleanProperty(IS_KOTLIN_PROJECT))
+}
+
+internal fun Project.kotlinProject() = this.extensions.extraProperties[IS_KOTLIN_PROJECT.key] as Boolean
+private fun Project.kotlinProject(kotlinProject: Boolean) {
+  this.extensions.extraProperties[IS_KOTLIN_PROJECT.key] = kotlinProject
+}
+
+private fun Properties.getBooleanProperty(pluginProperty: PluginProperty) =
+    (this.getProperty(pluginProperty.key)
+        ?.equals("true")
+        ?:pluginProperty.defaultValue) as Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/BaseConfigManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/BaseConfigManager.kt
@@ -48,7 +48,6 @@ class BaseConfigManager(override val project: Project) : ConfigManager {
   }
 
   private fun addDependencies() {
-    project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.2")
     project.dependencies.add("implementation", "com.google.guava:guava:29.0-jre") // This is only required because the version pulled in as a transitive dependency has CVE vulnerabilities
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/JavaPluginManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/JavaPluginManager.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.gradle.pluginmanagers
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaLibraryPlugin
+import uk.gov.justice.digital.hmpps.gradle.PluginManager
+
+class JavaPluginManager(override val project: Project) : PluginManager<JavaLibraryPlugin> {
+
+  override fun configure() {}
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManager.kt
@@ -21,6 +21,7 @@ class KotlinPluginManager(override val project: Project) : PluginManager<KotlinP
   }
 
   private fun addDependencies() {
+    project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.2")
     project.dependencies.add("implementation", "org.jetbrains.kotlin:kotlin-reflect")
 
     project.dependencies.add("testImplementation", "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/ProjectRunner.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/ProjectRunner.kt
@@ -5,6 +5,7 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import uk.gov.justice.digital.hmpps.gradle.PROJECT_PROPERTY_FILE
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -117,7 +118,8 @@ private fun makeSettingsScript(projectDir: File, settingsFileName: String, proje
 }
 
 private fun makePropertiesFile(projectDir: File, properties: String) {
-  val propertiesFile = File(projectDir, "gradle.properties")
+  if (properties.isEmpty()) return
+  val propertiesFile = File(projectDir, PROJECT_PROPERTY_FILE)
   Files.writeString(propertiesFile.toPath(), properties)
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/ProjectRunner.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/ProjectRunner.kt
@@ -14,7 +14,7 @@ import kotlin.streams.asStream
 
 data class ProjectDetails(
     val projectDir: File, val projectName: String, val packageDir: String, val mainClassName: String, val mainClass: String,
-    val buildScriptName: String, val buildScript: String, val settingsFileName: String, val testClass: String) {
+    val buildScriptName: String, val buildScript: String, val settingsFileName: String, val testClass: String, val properties: String) {
   override fun toString(): String = projectName
 }
 
@@ -32,6 +32,7 @@ fun makeProject(projectDetails: ProjectDetails) {
     makeSrcFile(projectDir, packageDir, mainClassName, mainClass)
     makeTestSrcFile(projectDir, packageDir, mainClassName, testClass)
     makeSettingsScript(projectDir, settingsFileName, projectName)
+    makePropertiesFile(projectDir, properties)
     makeGitRepo(projectDir)
   }
 }
@@ -113,6 +114,11 @@ private fun makeSettingsScript(projectDir: File, settingsFileName: String, proje
         rootProject.name = "$projectName"
       """.trimIndent()
   Files.writeString(settingsFile.toPath(), settingsScript)
+}
+
+private fun makePropertiesFile(projectDir: File, properties: String) {
+  val propertiesFile = File(projectDir, "gradle.properties")
+  Files.writeString(propertiesFile.toPath(), properties)
 }
 
 private fun makeGitRepo(projectDir: File) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/TestFixtures.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/TestFixtures.kt
@@ -42,7 +42,8 @@ fun javaProjectDetails(projectDir: File) =
                   assertThat("anything").isEqualTo("anything");
               }
           }
-        """.trimIndent()
+        """.trimIndent(),
+        properties = ""
     )
 
 fun kotlinProjectDetails(projectDir: File) =
@@ -83,5 +84,6 @@ fun kotlinProjectDetails(projectDir: File) =
                   assertThat("anything").isEqualTo("anything")
               }
           }
-        """.trimIndent()
+        """.trimIndent(),
+        properties = ""
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/configmanagers/AppInsightsConfigManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/configmanagers/AppInsightsConfigManagerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.gradle.functional.configmanagers
 
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.params.ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/pluginmanagers/KotlinPluginManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/pluginmanagers/KotlinPluginManagerTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.gradle.functional.pluginmanagers
+
+import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.gradle.ProjectProperties.IS_KOTLIN_PROJECT
+import uk.gov.justice.digital.hmpps.gradle.functional.GradleBuildTest
+import uk.gov.justice.digital.hmpps.gradle.functional.ProjectDetails
+import uk.gov.justice.digital.hmpps.gradle.functional.buildProject
+import uk.gov.justice.digital.hmpps.gradle.functional.findJar
+import uk.gov.justice.digital.hmpps.gradle.functional.javaProjectDetails
+import uk.gov.justice.digital.hmpps.gradle.functional.makeProject
+import java.util.jar.JarFile
+
+class KotlinPluginManagerTest : GradleBuildTest() {
+
+  companion object {
+    @JvmStatic
+    fun javaProjectWithKotlinTurnedOff() = listOf(
+        Arguments.of(javaProjectDetails(projectDir).copy(properties = """${IS_KOTLIN_PROJECT.name}=false""")),
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource("defaultProjectDetails")
+  fun `The Kotlin plugin is applied by default`(projectDetails: ProjectDetails) {
+    makeProject(projectDetails)
+
+    val result = buildProject(projectDir, "assemble")
+    Assertions.assertThat(result.task(":assemble")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val file = findJar(projectDir, projectDetails.projectName)
+    val jarFile = JarFile(file)
+    Assertions.assertThat(jarContainsKotlinDependency(jarFile)).isTrue
+
+  }
+
+  @ParameterizedTest
+  @MethodSource("javaProjectWithKotlinTurnedOff")
+  fun `The Kotlin plugin can be turned off`(projectDetails: ProjectDetails) {
+    makeProject(projectDetails)
+
+    val result = buildProject(projectDir, "assemble")
+    Assertions.assertThat(result.task(":assemble")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val file = findJar(projectDir, projectDetails.projectName)
+    val jarFile = JarFile(file)
+    Assertions.assertThat(jarContainsKotlinDependency(jarFile)).isFalse
+
+  }
+
+  private fun jarContainsKotlinDependency(jar: JarFile): Boolean =
+      jar.versionedStream().anyMatch { it.realName.contains("kotlin") }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/pluginmanagers/KotlinPluginManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/pluginmanagers/KotlinPluginManagerTest.kt
@@ -5,7 +5,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import uk.gov.justice.digital.hmpps.gradle.ProjectProperties.IS_KOTLIN_PROJECT
+import uk.gov.justice.digital.hmpps.gradle.PluginProperty.IS_KOTLIN_PROJECT
 import uk.gov.justice.digital.hmpps.gradle.functional.GradleBuildTest
 import uk.gov.justice.digital.hmpps.gradle.functional.ProjectDetails
 import uk.gov.justice.digital.hmpps.gradle.functional.buildProject
@@ -19,7 +19,7 @@ class KotlinPluginManagerTest : GradleBuildTest() {
   companion object {
     @JvmStatic
     fun javaProjectWithKotlinTurnedOff() = listOf(
-        Arguments.of(javaProjectDetails(projectDir).copy(properties = """${IS_KOTLIN_PROJECT.name}=false""")),
+        Arguments.of(javaProjectDetails(projectDir).copy(properties = """${IS_KOTLIN_PROJECT.key}=false""")),
     )
   }
 


### PR DESCRIPTION
The problem is that normally we would use a [Gradle Plugin Extension](https://guides.gradle.org/implementing-gradle-plugins/#modeling_dsl_like_apis) to make our plugin configurable - but unfortunately when it comes to applying 3rd party plugins we have to decide whether to apply the plugin before the Extension has been configured by the build so we cannot use that mechanism to make 3rd party plugins optional.

This solution uses a bespoke `dps-gradle-spring-boot.properties` file to hold any properties that relate to applying 3rd party plugins - we check it for property `kotlinProject=[true|false]` which defaults to true.

The downside to this solution is that there is yet another file required in the base project.  And also that we could add further extension properties in the buildScript DSL for configuration that doesn't apply to 3rd party plugins - giving us 2 places to add properties for our plugin.

The upside is that this solution is bespoke to our plugin and does not have the drawbacks of using `gradle.properties`.