### PR TITLE
DT-1301 Don't set jvm target until all KotlinCompile tasks are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently we recommend 1.1.2 due to issues with Application Insights Agent V3 in
 
 ## Release Notes
 
+##### [2.0.1](release-notes/2.0.1.md)
 ##### [2.0.0](release-notes/2.0.0.md)
 ##### [1.1.2  - recommended version](release-notes/1.1.2.md)
 ##### [1.1.1](release-notes/1.1.1.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "2.0.0"
+version = "2.0.1"
 
 gradlePlugin {
   plugins {

--- a/release-notes/2.0.1.md
+++ b/release-notes/2.0.1.md
@@ -1,0 +1,3 @@
+# 2.0.1
+
+Bug fix to set the JVM target for KotlinCompile tasks once all such tasks have been evaluated.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManager.kt
@@ -8,8 +8,11 @@ import uk.gov.justice.digital.hmpps.gradle.PluginManager
 class KotlinPluginManager(override val project: Project) : PluginManager<KotlinPluginWrapper> {
 
   override fun configure() {
-    setKotlinCompileJvmVersion()
     addDependencies()
+  }
+
+  override fun afterEvaluate() {
+    setKotlinCompileJvmVersion()
   }
 
   private fun setKotlinCompileJvmVersion() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/pluginmanagers/KotlinPluginManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/functional/pluginmanagers/KotlinPluginManagerTest.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.gradle.functional.pluginmanagers
+
+import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.gradle.functional.GradleBuildTest
+import uk.gov.justice.digital.hmpps.gradle.functional.ProjectDetails
+import uk.gov.justice.digital.hmpps.gradle.functional.buildProject
+import uk.gov.justice.digital.hmpps.gradle.functional.kotlinProjectDetails
+import uk.gov.justice.digital.hmpps.gradle.functional.makeProject
+
+class KotlinPluginManagerTest : GradleBuildTest(){
+
+  companion object {
+    @JvmStatic
+    fun kotlinOnlyProject() = listOf(
+      Arguments.of(kotlinProjectDetails(projectDir))
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource("kotlinOnlyProject")
+  fun `Sets JVM target for Kotlin compile tasks`(projectDetails: ProjectDetails) {
+    makeProject(projectDetails)
+
+    // This compile would fail at JVM 1.6 which is the default
+    val result = buildProject(projectDir, "compileKotlin")
+    Assertions.assertThat(result.task(":compileKotlin")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManagerTest.kt
@@ -32,10 +32,4 @@ class KotlinPluginManagerTest : UnitTest() {
         tuple("com.nhaarman.mockitokotlin2", "mockito-kotlin")
       )
   }
-
-  @Test
-  fun `Should set jvm target for Kotlin tasks`() {
-    assertThat((project.tasks.getByPath("compileKotlin") as KotlinCompile).kotlinOptions.jvmTarget).isEqualTo("11")
-    assertThat((project.tasks.getByPath("compileTestKotlin") as KotlinCompile).kotlinOptions.jvmTarget).isEqualTo("11")
-  }
 }


### PR DESCRIPTION
Required when using the sourceSets plugin