### PR TITLE
DT-1638 Upgrades (inc. Spring Boot 2.4.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 
 ## Release Notes
 
+##### [3.1.1](release-notes/3.1.1.md)
 ##### [3.1.0](release-notes/3.1.0.md)
 ##### [3.0.1](release-notes/3.0.1.md)
 ##### [3.0.0](release-notes/3.0.0.md)
@@ -36,7 +37,7 @@ In your `build.gradle.kts` (or `build.gradle` for Java) add the following line t
 ```
 plugins {
   ...
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.1"
   ...
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
   id("maven-publish")
   id("com.github.ben-manes.versions") version "0.36.0"
   id("se.patrikerdes.use-latest-versions") version "0.2.15"
-  id("org.owasp.dependencycheck") version "6.1.0"
+  id("org.owasp.dependencycheck") version "6.1.1"
   id("com.adarshr.test-logger") version "2.1.1"
-  id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
+  id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
 }
 
 repositories {
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "3.1.0"
+version = "3.1.1"
 
 gradlePlugin {
   plugins {
@@ -53,15 +53,15 @@ pluginBundle {
 dependencies {
   implementation(kotlin("reflect"))
 
-  implementation("org.springframework.boot:spring-boot-gradle-plugin:2.4.2")
+  implementation("org.springframework.boot:spring-boot-gradle-plugin:2.4.3")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.30")
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.11.RELEASE")
-  implementation("org.owasp:dependency-check-gradle:6.1.0")
+  implementation("org.owasp:dependency-check-gradle:6.1.1")
   implementation("com.github.ben-manes:gradle-versions-plugin:0.36.0")
   implementation("com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.2.4")
   implementation("com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:2.1.1")
   implementation("se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin:0.2.15")
-  implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:9.4.1")
+  implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:10.0.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-junit-jupiter:3.7.7")

--- a/release-notes/3.1.1.md
+++ b/release-notes/3.1.1.md
@@ -1,0 +1,17 @@
+# 3.1.1
+
+## Upgrade to Spring Boot 2.4.3
+
+This includes an [upgrade to Spring Boot 2.4.3](https://github.com/spring-projects/spring-boot/releases/tag/v2.4.3) which mainly includes bug fixes and version upgrades
+
+
+## Version upgrades
+
+Plugin dependencies:
+- org.owasp.dependencycheck [6.1.0 -> 6.1.1]
+- org.jlleitschuh.gradle.ktlint [9.4.1 -> 10.0.0]
+
+Applied jar dependencies:
+- net.logstash.logback:logstash-logback-encoder [6.5 -> 6.6]
+- com.fasterxml.jackson.module:jackson-module-kotlin [2.12.0 -> 2.12.1]
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
@@ -28,7 +28,7 @@ class AppInsightsConfigManager(override val project: Project) : ConfigManager {
   }
 
   private fun addDependencies() {
-    project.dependencies.add("implementation", "net.logstash.logback:logstash-logback-encoder:6.5")
+    project.dependencies.add("implementation", "net.logstash.logback:logstash-logback-encoder:6.6")
     project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-spring-boot-starter:$APP_INSIGHTS_SDK_VERSION")
     project.dependencies.add("implementation", "com.microsoft.azure:applicationinsights-logging-logback:$APP_INSIGHTS_SDK_VERSION")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/KotlinPluginManager.kt
@@ -24,7 +24,7 @@ class KotlinPluginManager(override val project: Project) : PluginManager<KotlinP
   }
 
   private fun addDependencies() {
-    project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin:2.12.0")
+    project.dependencies.add("implementation", "com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1")
     project.dependencies.add("implementation", "org.jetbrains.kotlin:kotlin-reflect")
 
     project.dependencies.add("testImplementation", "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")


### PR DESCRIPTION
The latest Spring Boot upgrade pulls in new versions to mitigate CVEs 2021-21290 and 2020-13962