### PR TITLE
Support Apple Silicon Macs for WebFlux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 
 ## Release Notes
 
+##### [4.0.4](release-notes/4.0.4.md)
 ##### [4.0.3](release-notes/4.0.3.md)
 ##### [4.0.2](release-notes/4.0.2.md)
 ##### [4.0.1](release-notes/4.0.1.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "4.0.3"
+version = "4.0.4-beta"
 
 gradlePlugin {
   plugins {

--- a/release-notes/4.0.4.md
+++ b/release-notes/4.0.4.md
@@ -1,0 +1,5 @@
+# 4.0.4
+
+## Support Apple Silicon Macs in development
+Add io.netty:netty-resolver-dns-native-macos::osx-aarch_64 alongside osx-x86_64 version when building on a Apple Silicon Mac.
+CircleCi build would be unaffected given it uses linux.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/SpringBootPluginManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/gradle/pluginmanagers/SpringBootPluginManagerTest.kt
@@ -3,8 +3,18 @@ package uk.gov.justice.digital.hmpps.gradle.pluginmanagers
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.tuple
 import org.assertj.core.groups.Tuple
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.gradle.UnitTest
+import uk.gov.justice.digital.hmpps.gradle.functional.GradleBuildTest
+import uk.gov.justice.digital.hmpps.gradle.functional.buildProject
+import uk.gov.justice.digital.hmpps.gradle.functional.findJar
+import uk.gov.justice.digital.hmpps.gradle.functional.kotlinProjectDetails
+import uk.gov.justice.digital.hmpps.gradle.functional.makeProject
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
 
 class SpringBootPluginManagerTest : UnitTest() {
   @Test
@@ -28,4 +38,104 @@ class SpringBootPluginManagerTest : UnitTest() {
 
       )
   }
+
+
+  class SpringBootPluginManagerGradleTest : GradleBuildTest() {
+    @Nested
+    @DisplayName("When WebFlux is included in project")
+    inner class WithWebFlux {
+      private val project = """
+          plugins {
+            id("uk.gov.justice.hmpps.gradle-spring-boot") version "0.1.0"
+          }
+          dependencies {
+              implementation("org.springframework.boot:spring-boot-starter-webflux");
+              implementation("org.springframework.boot:spring-boot-starter-oauth2-client");
+              
+          }
+      """.trimIndent()
+
+      @Test
+      internal fun `when apple silicon arm 64 should include osx-aarch_64 as well as default osx-x86_64 version`() {
+        val jarFile = jarFileForProject(project, architecture = "aarch64")
+
+        val version = getNettyResolverDNSNativeMacosVersion(jarFile)
+
+        assertThat(jarContainsNettyResolverDNSNativeMacos(jarFile, version, "osx-aarch_64")).isTrue
+        assertThat(jarContainsNettyResolverDNSNativeMacos(jarFile, version, "osx-x86_64")).isTrue
+      }
+
+      @Test
+      internal fun `when intel should not include osx-aarch_64 just default osx-x86_64 version`() {
+        val jarFile = jarFileForProject(project, architecture = "amd64")
+
+        val version = getNettyResolverDNSNativeMacosVersion(jarFile)
+
+        assertThat(jarContainsNettyResolverDNSNativeMacos(jarFile, version, "osx-aarch_64")).isFalse
+        assertThat(jarContainsNettyResolverDNSNativeMacos(jarFile, version, "osx-x86_64")).isTrue
+      }
+
+      @Test
+      internal fun `when any other architecture should not include osx-aarch_64 just default osx-x86_64 version`() {
+        val jarFile = jarFileForProject(project, architecture = "s390")
+
+        val version = getNettyResolverDNSNativeMacosVersion(jarFile)
+
+        assertThat(jarContainsNettyResolverDNSNativeMacos(jarFile, version, "osx-aarch_64")).isFalse
+        assertThat(jarContainsNettyResolverDNSNativeMacos(jarFile, version, "osx-x86_64")).isTrue
+      }
+
+    }
+
+    @Nested
+    @DisplayName("When WebFlux is not included in project")
+    inner class WithNoWebFlux {
+
+      @Test
+      internal fun `should not add netty mac arm64 version when webflux not a dependency`() {
+        val project = """
+          plugins {
+            id("uk.gov.justice.hmpps.gradle-spring-boot") version "0.1.0"
+          }
+          dependencies {
+              implementation("org.springframework.boot:spring-boot-starter-web");
+              implementation("org.springframework.boot:spring-boot-starter-oauth2-client");
+              
+          }
+      """.trimIndent()
+
+        val jarFile = jarFileForProject(project)
+
+        assertThat(getNettyResolverDNSNativeMacosJarEntry(jarFile, "osx-x86_64")).isNull()
+        assertThat(getNettyResolverDNSNativeMacosJarEntry(jarFile, "osx-aarch_64")).isNull()
+      }
+
+    }
+
+    private fun jarFileForProject(gradleContents: String, architecture: String = "aarch64"): JarFile {
+      val projectDetails = kotlinProjectDetails(projectDir).copy(buildScript = gradleContents)
+      makeProject(projectDetails)
+      val result = buildProject(projectDir, "bootJar", "-Dos.arch=$architecture")
+      assertThat(result.task(":bootJar")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+      return JarFile(findJar(projectDir, projectDetails.projectName))
+    }
+  }
+
+}
+
+
+private fun jarContainsNettyResolverDNSNativeMacos(jar: JarFile, version: String, architecture: String): Boolean =
+  jar.getJarEntry("BOOT-INF/lib/netty-resolver-dns-native-macos-$version.Final-$architecture.jar") != null
+
+private fun getNettyResolverDNSNativeMacosJarEntry(jar: JarFile, architecture: String): JarEntry? =
+  jar.entries().asSequence()
+    .filter { it.name.startsWith("BOOT-INF/lib/netty-resolver-dns-native-macos") }
+    .filter { it.name.contains(".Final-$architecture.jar") }
+    .firstOrNull()
+
+private fun getNettyResolverDNSNativeMacosVersion(jar: JarFile): String {
+  val entry = getNettyResolverDNSNativeMacosJarEntry(jar, "osx-x86_64")
+  val versionExtractor = "netty-resolver-dns-native-macos-([0-9.]+).Final-osx-x86_64.jar".toRegex()
+  return entry?.let { versionExtractor.find(entry.name)?.groupValues?.get(1) }
+    ?: throw IllegalStateException("Could not extract version from $entry")
 }


### PR DESCRIPTION
When using WebFlux which depends on netty, the netty dns resolver has OS/chip architecture specific jar versions.
Netty has consciously chosen not to include the Apple Silicon version of that jar but instead bundles the intel Mac version simply because the Intel Macs are more popular. The Apple Silicon version has to be included manually.

This update to plug-in does the following:

Also includes netty-resolver-dns-native-macos-<version>.Final-osx-aarch_64.jar in the following scenarios:

- WebFlux is included as a dependency
- The build is running on a osx-aarch_64 machine

The official CircleCI build would obviously be unaffected give it is runs on linux.
