### PR TITLE
Use latest version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 
 ## Release Notes
 
+##### [4.4.1](release-notes/4.4.1.md)
 ##### [4.3.4](release-notes/4.3.4.md)
 ##### [4.3.3](release-notes/4.3.3.md)
 ##### [4.3.2](release-notes/4.3.2.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "4.3.4-beta"
+version = "4.4.1-beta"
 
 gradlePlugin {
   plugins {

--- a/release-notes/4.4.1.md
+++ b/release-notes/4.4.1.md
@@ -1,0 +1,15 @@
+# 4.4.1
+
+Although this is identical to `4.3.4` we needed to move beyond `4.4.0` as version `4.4.0-beta` had previously been published to the Gradle Plugin Portal before being revoked and hence is being pulled in by `useLatestVersions`. 
+
+## Upgrade to Spring Boot 2.7.2
+
+This includes an [upgrade to Spring Boot 2.7.2](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.2)
+
+## Upgrade to Kotlin 1.7.10
+
+This includes an [upgrade to Kotlin 1.7.10](https://github.com/JetBrains/kotlin/releases/tag/v1.7.10).
+
+## Version upgrades
+ - io.spring.dependency-management:io.spring.dependency-management.gradle.plugin [1.0.11.RELEASE -> 1.0.12.RELEASE]
+


### PR DESCRIPTION
Move version 4.3.4 to 4.4.1 as version 4.4.0-beta was previously puished but then reverted, however it still exists in Gradle Plugin Portal.