### PR TITLE
Upgrading to spring boot 2.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 * CVEs causing `dependencyCheckAnalyze` failures are mitigated in a single place rather than in each and every project
 
 ## Release Notes
+##### [4.5.6](release-notes/4.5.6.md)
 ##### [4.5.5](release-notes/4.5.5.md)
 ##### [4.5.4](release-notes/4.5.4.md)
 ##### [4.5.3](release-notes/4.5.3.md)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In your `build.gradle.kts` (or `build.gradle` for Java) add the following line t
 ```
 plugins {
   ...
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.5"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.6"
   ...
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
   id("com.gradle.plugin-publish") version "1.0.0"
   id("java-gradle-plugin")
   id("maven-publish")
-  id("com.github.ben-manes.versions") version "0.43.0"
+  id("com.github.ben-manes.versions") version "0.42.0"
   id("se.patrikerdes.use-latest-versions") version "0.2.18"
   id("org.owasp.dependencycheck") version "7.3.0"
   id("com.adarshr.test-logger")
@@ -58,11 +58,11 @@ dependencies {
   implementation(kotlin("reflect"))
 
   implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.5")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.0")
   implementation("org.owasp:dependency-check-core:7.3.0")
   implementation("org.owasp:dependency-check-gradle:7.3.0")
-  implementation("com.github.ben-manes:gradle-versions-plugin:0.43.0")
+  implementation("com.github.ben-manes:gradle-versions-plugin:0.42.0")
   implementation("com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.4.1")
   implementation("com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:$testLoggerVersion")
   implementation("se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin:0.2.18")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,13 +3,13 @@ import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.7.10"
+  kotlin("jvm") version "1.7.20"
   id("com.gradle.plugin-publish") version "1.0.0"
   id("java-gradle-plugin")
   id("maven-publish")
-  id("com.github.ben-manes.versions") version "0.42.0"
+  id("com.github.ben-manes.versions") version "0.43.0"
   id("se.patrikerdes.use-latest-versions") version "0.2.18"
-  id("org.owasp.dependencycheck") version "7.2.0"
+  id("org.owasp.dependencycheck") version "7.3.0"
   id("com.adarshr.test-logger") version "3.0.0" // did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
   id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
 }
@@ -55,19 +55,19 @@ dependencies {
 
   implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.5")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
-  implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.13.RELEASE")
-  implementation("org.owasp:dependency-check-core:7.2.0")
-  implementation("org.owasp:dependency-check-gradle:7.2.0")
-  implementation("com.github.ben-manes:gradle-versions-plugin:0.42.0")
+  implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.0")
+  implementation("org.owasp:dependency-check-core:7.3.0")
+  implementation("org.owasp:dependency-check-gradle:7.3.0")
+  implementation("com.github.ben-manes:gradle-versions-plugin:0.43.0")
   implementation("com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.4.1")
   implementation("com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:3.0.0") // did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
   implementation("se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin:0.2.18")
   implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:11.0.0")
 
-  testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
-  testImplementation("org.mockito:mockito-junit-jupiter:4.8.0")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
+  testImplementation("org.mockito:mockito-junit-jupiter:4.8.1")
   testImplementation("org.assertj:assertj-core:3.23.1")
-  testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.35.0")
+  testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.36.0")
   testImplementation("com.google.code.gson:gson:2.9.1")
   testImplementation("org.eclipse.jgit:org.eclipse.jgit:6.3.0.202209071007-r")
   // Had to include this when I had the same error as https://youtrack.jetbrains.com/issue/KT-49547, this links to https://github.com/gradle/gradle/issues/16774 which has includes a workaround

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "4.5.5"
+version = "4.5.6-beta"
 
 gradlePlugin {
   plugins {
@@ -53,7 +53,7 @@ pluginBundle {
 dependencies {
   implementation(kotlin("reflect"))
 
-  implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.4")
+  implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.5")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.13.RELEASE")
   implementation("org.owasp:dependency-check-core:7.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
   id("com.gradle.plugin-publish") version "1.0.0"
   id("java-gradle-plugin")
   id("maven-publish")
-  id("com.github.ben-manes.versions") version "0.42.0"
+  id("com.github.ben-manes.versions")
   id("se.patrikerdes.use-latest-versions") version "0.2.18"
   id("org.owasp.dependencycheck") version "7.3.0"
   id("com.adarshr.test-logger")
@@ -54,6 +54,11 @@ pluginBundle {
 // this version is also set in settings.gradle.kts as needed by the plugins block
 val testLoggerVersion by extra("3.0.0")
 
+// Versions plugin requires gradle 7 so pin to 0.42.0 until can upgrade
+// https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.43.0
+// this version is also set in settings.gradle.kts as needed by the plugins block
+val versionsVersion by extra("0.42.0")
+
 dependencies {
   implementation(kotlin("reflect"))
 
@@ -62,7 +67,7 @@ dependencies {
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.0")
   implementation("org.owasp:dependency-check-core:7.3.0")
   implementation("org.owasp:dependency-check-gradle:7.3.0")
-  implementation("com.github.ben-manes:gradle-versions-plugin:0.42.0")
+  implementation("com.github.ben-manes:gradle-versions-plugin:$versionsVersion")
   implementation("com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.4.1")
   implementation("com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:$testLoggerVersion")
   implementation("se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin:0.2.18")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   id("com.github.ben-manes.versions") version "0.43.0"
   id("se.patrikerdes.use-latest-versions") version "0.2.18"
   id("org.owasp.dependencycheck") version "7.3.0"
-  id("com.adarshr.test-logger") version "3.0.0" // did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
+  id("com.adarshr.test-logger")
   id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
 }
 
@@ -50,6 +50,10 @@ pluginBundle {
   tags = listOf("hmpps", "spring-boot")
 }
 
+// did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
+// this version is also set in settings.gradle.kts as needed by the plugins block
+val testLoggerVersion by extra("3.0.0")
+
 dependencies {
   implementation(kotlin("reflect"))
 
@@ -60,7 +64,7 @@ dependencies {
   implementation("org.owasp:dependency-check-gradle:7.3.0")
   implementation("com.github.ben-manes:gradle-versions-plugin:0.43.0")
   implementation("com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.4.1")
-  implementation("com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:3.0.0") // did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
+  implementation("com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:$testLoggerVersion")
   implementation("se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin:0.2.18")
   implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:11.0.0")
 

--- a/release-notes/4.5.6.md
+++ b/release-notes/4.5.6.md
@@ -3,3 +3,16 @@
 ## Upgrade to Spring Boot 2.7.5
 This includes an [upgrade to Spring Boot 2.7.5](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.5)
 
+## Upgrade to Kotlin 1.7.20
+This includes an [upgrade to Kotlin 1.7.20](https://github.com/JetBrains/kotlin/releases/tag/v1.7.20/) which is a bugfix release.
+
+## Version upgrades
+ - com.github.ben-manes:gradle-versions-plugin [0.42.0 -> 0.43.0]
+ - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.42.0 -> 0.43.0]
+ - io.spring.dependency-management:io.spring.dependency-management.gradle.plugin [1.0.13.RELEASE -> 1.1.0]
+ - net.javacrumbs.json-unit:json-unit-assertj [2.35.0 -> 2.36.0]
+ - org.junit.jupiter:junit-jupiter [5.9.0 -> 5.9.1]
+ - org.mockito:mockito-junit-jupiter [4.8.0 -> 4.8.1]
+ - org.owasp:dependency-check-core [7.2.0 -> 7.3.0]
+ - org.owasp:dependency-check-gradle [7.2.0 -> 7.3.0]
+ - org.owasp.dependencycheck:org.owasp.dependencycheck.gradle.plugin [7.2.0 -> 7.3.0]

--- a/release-notes/4.5.6.md
+++ b/release-notes/4.5.6.md
@@ -4,7 +4,10 @@
 This includes an [upgrade to Spring Boot 2.7.5](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.5)
 
 ## Upgrade to Kotlin 1.7.20
-This includes an [upgrade to Kotlin 1.7.20](https://github.com/JetBrains/kotlin/releases/tag/v1.7.20/) which is a bugfix release.
+This includes an [upgrade to Kotlin 1.7.20](https://github.com/JetBrains/kotlin/releases/tag/v1.7.20/)
+
+## Upgrade to Application Insights 3.4.2
+This includes an [upgrade to Application Insights 3.4.2](https://github.com/microsoft/ApplicationInsights-Java/releases/tag/3.4.2)
 
 ## Version upgrades
  - com.github.ben-manes:gradle-versions-plugin [0.42.0 -> 0.43.0]
@@ -16,3 +19,5 @@ This includes an [upgrade to Kotlin 1.7.20](https://github.com/JetBrains/kotlin/
  - org.owasp:dependency-check-core [7.2.0 -> 7.3.0]
  - org.owasp:dependency-check-gradle [7.2.0 -> 7.3.0]
  - org.owasp.dependencycheck:org.owasp.dependencycheck.gradle.plugin [7.2.0 -> 7.3.0]
+ - com.microsoft.azure:applicationinsights-agent [3.4.1 -> 3.4.2]
+ - org.junit.vintage:junit-vintage-engine [5.9.0 -> 5.9.1]

--- a/release-notes/4.5.6.md
+++ b/release-notes/4.5.6.md
@@ -1,0 +1,5 @@
+# 4.5.6
+
+## Upgrade to Spring Boot 2.7.5
+This includes an [upgrade to Spring Boot 2.7.5](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.5)
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,12 @@ pluginManagement {
   // did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
   // this version is also set in build.gradle.kts as needed by the plugins block
   val testLoggerVersion by extra("3.0.0")
-    plugins {
-      id("com.adarshr.test-logger") version testLoggerVersion
-    }
+
+  // Versions plugin requires gradle 7 so pin to 0.42.0 until can upgrade
+  // this version is also set in build.gradle.kts as needed by the plugins block
+  val versionsVersion by extra("0.42.0")
+  plugins {
+    id("com.adarshr.test-logger") version testLoggerVersion
+    id("com.github.ben-manes.versions") version versionsVersion
+  }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,10 @@
 rootProject.name = "dps-gradle-spring-boot"
+
+pluginManagement {
+  // did not upgrade to 3.2.0 because experienced ListenerNotificationException - same issue as https://github.com/radarsh/gradle-test-logger-plugin/issues/241
+  // this version is also set in build.gradle.kts as needed by the plugins block
+  val testLoggerVersion by extra("3.0.0")
+    plugins {
+      id("com.adarshr.test-logger") version testLoggerVersion
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.Copy
 import uk.gov.justice.digital.hmpps.gradle.ConfigManager
 
 private const val APP_INSIGHTS_SDK_VERSION = "2.6.4"
-private const val APP_INSIGHTS_AGENT_VERSION = "3.4.1"
+private const val APP_INSIGHTS_AGENT_VERSION = "3.4.2"
 
 class AppInsightsConfigManager(override val project: Project) : ConfigManager {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/BaseConfigManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/BaseConfigManager.kt
@@ -44,6 +44,6 @@ class BaseConfigManager(override val project: Project) : ConfigManager {
     project.tasks.withType(Test::class.java) { it.useJUnitPlatform() }
     project.configurations.findByName("testImplementation")?.dependencies?.find { it.group == "junit" }?.version
       ?.takeIf { it.startsWith("4") }
-      .run { project.dependencies.add("testImplementation", "org.junit.vintage:junit-vintage-engine:5.9.0") }
+      .run { project.dependencies.add("testImplementation", "org.junit.vintage:junit-vintage-engine:5.9.1") }
   }
 }


### PR DESCRIPTION
- Upgrading to latest version spring boot 2.7.5. 
- This is necessary due to the fact there was the vulnerability scan failed in io.projectreactor.netty:reactor-netty-http(1.0.23) project which is fixed in the latest version (1.0.25) and this is present latest version of spring boot 2.7.5
