### PR TITLE
suppress spring web for security vulnerability CVE-2016-1000027

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 * CVEs causing `dependencyCheckAnalyze` failures are mitigated in a single place rather than in each and every project
 
 ## Release Notes
+##### [4.8.1](release-notes/4.8.1.md)
 ##### [4.8.0](release-notes/4.8.0.md)
 ##### [4.7.4](release-notes/4.7.4.md)
 ##### [4.7.3](release-notes/4.7.3.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "4.8.0"
+version = "4.8.1-beta-1"
 
 gradlePlugin {
   plugins {

--- a/release-notes/4.8.1.md
+++ b/release-notes/4.8.1.md
@@ -1,0 +1,19 @@
+# 4.8.1
+
+## Suppress Spring Web 5.3.24 vulnerability (CVE-2016-1000027)
+spring-web-5.3.24.jar
+can be suppressed as we are not using java serialization and deserialization explicitly
+
+From the CVE:
+> Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required.
+
+## False positive suppression for snakeyaml vulnerability (CVE-2022-3064,CVE-2021-4235)
+
+Snakeyaml 1.33 has no known upgrade path and is vulnerable to Denial of Service attacks. 
+
+From the CVE:
+> Those using Snakeyaml to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input,
+We're not parsing untrusted YAML so can suppress the vulnerability.
+
+## False positive suppression for json patch vulnerability (CVE-2021-4279)
+json-patch jar is not referenced directly in the project. The vulnerability is fixed in 3.1.1

--- a/src/main/resources/.trivyignore
+++ b/src/main/resources/.trivyignore
@@ -32,3 +32,6 @@ CVE-2022-42889
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for spring-web 5.3.24 as bundled with spring boot
+#   can be suppressed as we are not using java serialization and deserialization explicitly
+CVE-2016-1000027

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -463,13 +463,6 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: spring-webmvc-5.3.24.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
-    <cve>CVE-2016-1000027</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
    file name: spring-webflux-5.3.20.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webflux@.*$</packageUrl>

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -463,6 +463,13 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
+   file name: spring-webmvc-5.3.24.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
    file name: spring-webflux-5.3.20.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webflux@.*$</packageUrl>

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -204,6 +204,13 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
+   file name: json-patch-1.13.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.github\.java-json-tools/json\-patch@.*$</packageUrl>
+    <cve>CVE-2021-4279</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
    file name: json-smart-2.3.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/net\.minidev/json\-smart@.*$</packageUrl>
@@ -629,6 +636,20 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: snakeyaml-1.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+    <vulnerabilityName>CVE-2022-3064</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: snakeyaml-1.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+    <vulnerabilityName>CVE-2021-4235</vulnerabilityName>
   </suppress>
 
   <!-- suppressed as the UNWRAP_SINGLE_VALUE_ARRAYS is not enabled (except in assessments-api) -->


### PR DESCRIPTION
suppress spring web 5.3.24 for security vulnerability CVE-2016-100027 based on the recommendation below
https://mojdt.slack.com/archives/C69NWE339/p1673352394875419?thread_ts=1673351639.434189&cid=C69NWE339