### PR TITLE
Suppressing pkg:maven/com.squareup.okio/okio@1.17.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 * CVEs causing `dependencyCheckAnalyze` failures are mitigated in a single place rather than in each and every project
 
 ## Release Notes
+##### [4.9.2](release-notes/4.9.2.md)
 ##### [4.9.1](release-notes/4.9.1.md)
 ##### [4.9.0](release-notes/4.9.0.md)
 ##### [4.8.8](release-notes/4.8.8.md)
@@ -134,7 +135,7 @@ In your `build.gradle.kts` (or `build.gradle` for Java) add the following line t
 ```
 plugins {
   ...
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.9.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.9.2"
   ...
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "4.9.1"
+version = "4.9.2"
 
 gradlePlugin {
   website.set("https://github.com/ministryofjustice/dps-gradle-spring-boot")

--- a/release-notes/4.9.2.md
+++ b/release-notes/4.9.2.md
@@ -1,0 +1,7 @@
+# 4.9.2
+
+## Suppression for CVE-2023-3635
+
+Suppressing pkg:maven/com.squareup.okio/okio@1.17.5 until a new version of the applicationinsights-agent is released, as this has started failing the owasp check and blocking the pipeline for https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi.
+
+

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -758,4 +758,14 @@
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
     <cve>CVE-2023-35116</cve>
   </suppress>
+  <!-- suppress as a new version of the applicationinsights-agent neeeds to be released with the updated version of squareup.okio.
+   The version was updated here: https://github.com/microsoft/ApplicationInsights-Java/pull/3181 there has not been a new release
+   of applicationinsights yet.-->
+  <suppress until="2023-10-01Z">
+    <notes><![CDATA[
+   file name: applicationinsights-agent-3.4.14.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio@.*$</packageUrl>
+    <cve>CVE-2023-3635</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppressing pkg:maven/com.squareup.okio/okio@1.17.5 until a new version of the insights app is released, as this has started failing the owasp check and blocking our pipeline for https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi.
Below is the full report:
<img width="1699" alt="dependency_vuln_fail" src="https://github.com/ministryofjustice/dps-gradle-spring-boot/assets/135604838/7ec5d096-bd8c-4a3d-bce8-26e9caee8903">

And the build failure:
<img width="1452" alt="pipeline_failure" src="https://github.com/ministryofjustice/dps-gradle-spring-boot/assets/135604838/aac0e90e-53cc-4b75-b087-e0f42a9f095f">
