### PR TITLE
Suppressing pkg:maven/com.squareup.okio/okio@1.17.5 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 * CVEs causing `dependencyCheckAnalyze` failures are mitigated in a single place rather than in each and every project
 
 ## Release Notes
+##### [5.2.2](release-notes/5.2.3.md)
 ##### [5.2.2](release-notes/5.2.2.md)
 ##### [5.2.1](release-notes/5.2.1.md)
 ##### [5.2.0](release-notes/5.2.0.md)
@@ -23,6 +24,7 @@ This Gradle plugin is used to orchestrate DPS Spring Boot projects such that:
 <details>
   <summary>4.#</summary>
 
+##### [4.9.1](release-notes/4.9.2.md)
 ##### [4.9.1](release-notes/4.9.1.md)
 ##### [4.9.0](release-notes/4.9.0.md)
 ##### [4.8.8](release-notes/4.8.8.md)
@@ -144,7 +146,7 @@ In your `build.gradle.kts` (or `build.gradle` for Java) add the following line t
 ```
 plugins {
   ...
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.2.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.2.3"
   ...
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "5.2.2"
+version = "5.2.3"
 
 gradlePlugin {
   website.set("https://github.com/ministryofjustice/dps-gradle-spring-boot")

--- a/release-notes/4.9.2.md
+++ b/release-notes/4.9.2.md
@@ -1,0 +1,6 @@
+# 4.9.2
+
+## Suppression for CVE-2023-3635
+
+Suppressing pkg:maven/com.squareup.okio/okio@1.17.5 until a new version of the applicationinsights-agent is released, as this has started failing the owasp check and blocking the pipeline for https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi.
+

--- a/release-notes/5.2.3.md
+++ b/release-notes/5.2.3.md
@@ -1,0 +1,6 @@
+# 5.2.3
+
+## Suppression for CVE-2023-3635
+
+Suppressing pkg:maven/com.squareup.okio/okio@1.17.5 until a new version of the applicationinsights-agent is released, as this has started failing the owasp check and blocking the pipeline for https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi.
+

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -775,4 +775,11 @@
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
     <cve>CVE-2023-35116</cve>
   </suppress>
+  <suppress until="2023-10-01Z">
+    <notes><![CDATA[
+   file name: applicationinsights-agent-3.4.14.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio@.*$</packageUrl>
+    <cve>CVE-2023-3635</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppressing pkg:maven/com.squareup.okio/okio@1.17.5 until a new version of the insights app is released, as this has started failing the owasp check and blocking our pipeline for https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi.
Similar to https://github.com/ministryofjustice/dps-gradle-spring-boot/pull/286