### PR TITLE
Upgrade spring boot and app insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In your `build.gradle.kts` (or `build.gradle` for Java) add the following line t
 ```
 plugins {
   ...
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.4"
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In your `build.gradle.kts` (or `build.gradle` for Java) add the following line t
 ```
 plugins {
   ...
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.3"
   ...
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
   testImplementation("org.assertj:assertj-core:3.25.3")
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:3.2.7")
   testImplementation("com.google.code.gson:gson:2.10.1")
-  testImplementation("org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r")
+  testImplementation("org.eclipse.jgit:org.eclipse.jgit:6.9.0.202403050737-r")
   // Had to include this when I had the same error as https://youtrack.jetbrains.com/issue/KT-49547, this links to https://github.com/gradle/gradle/issues/16774 which has includes a workaround
   testRuntimeOnly(
     files(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.22"
+  kotlin("jvm") version "1.9.23"
   id("com.gradle.plugin-publish") version "1.2.1"
   id("java-gradle-plugin")
   id("maven-publish")
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "5.15.3"
+version = "5.15.4"
 
 gradlePlugin {
   website.set("https://github.com/ministryofjustice/dps-gradle-spring-boot")
@@ -50,7 +50,7 @@ gradlePlugin {
 dependencies {
   implementation(kotlin("reflect"))
 
-  implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.3")
+  implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.4")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4")
   implementation("org.owasp:dependency-check-core:8.4.2")
@@ -62,7 +62,7 @@ dependencies {
   implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:12.1.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
-  testImplementation("org.mockito:mockito-junit-jupiter:5.10.0")
+  testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
   testImplementation("org.assertj:assertj-core:3.25.3")
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:3.2.7")
   testImplementation("com.google.code.gson:gson:2.10.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
   implementation(kotlin("reflect"))
 
   implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.4")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+  implementation(kotlin("gradle-plugin"))
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4")
   implementation("org.owasp:dependency-check-core:8.4.2")
   implementation("org.owasp:dependency-check-gradle:8.4.2")

--- a/release-notes/5.x.md
+++ b/release-notes/5.x.md
@@ -1,5 +1,18 @@
 # 5.15.3
 
+## Upgrade to spring-boot 3.2.4
+This includes an [upgrade to Spring Boot 3.2.4](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.4)
+
+## Version Upgrades
+- com.microsoft.azure:applicationinsights-agent [3.4.19 -> 3.5.1]
+- com.microsoft.azure:applicationinsights-core [3.4.19 -> 3.5.1]
+- io.opentelemetry:opentelemetry-api [1.32.0 -> 1.36.0]
+
+## Test dependency upgrades
+- org.mockito:mockito-junit-jupiter [5.10.0 -> 5.11.0]
+
+# 5.15.3
+
 ## Upgrade to spring-boot 3.2.3
 This includes an [upgrade to Spring Boot 3.2.3](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.3)
 

--- a/release-notes/5.x.md
+++ b/release-notes/5.x.md
@@ -3,6 +3,9 @@
 ## Upgrade to spring-boot 3.2.4
 This includes an [upgrade to Spring Boot 3.2.4](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.4)
 
+## Upgrade to Kotlin 1.9.23
+This includes an [upgrade to Kotlin 1.9.23](https://github.com/JetBrains/kotlin/releases/tag/v1.9.23/)
+
 ## Version Upgrades
 - com.microsoft.azure:applicationinsights-agent [3.4.19 -> 3.5.1]
 - com.microsoft.azure:applicationinsights-core [3.4.19 -> 3.5.1]
@@ -10,6 +13,7 @@ This includes an [upgrade to Spring Boot 3.2.4](https://github.com/spring-projec
 
 ## Test dependency upgrades
 - org.mockito:mockito-junit-jupiter [5.10.0 -> 5.11.0]
+- org.eclipse.jgit:org.eclipse.jgit [6.8.0.202311291450-r -> 6.9.0.202403050737-r]
 
 # 5.15.3
 

--- a/release-notes/5.x.md
+++ b/release-notes/5.x.md
@@ -9,7 +9,7 @@ This includes an [upgrade to Kotlin 1.9.23](https://github.com/JetBrains/kotlin/
 ## Version Upgrades
 - com.microsoft.azure:applicationinsights-agent [3.4.19 -> 3.5.1]
 - com.microsoft.azure:applicationinsights-core [3.4.19 -> 3.5.1]
-- io.opentelemetry:opentelemetry-api [1.32.0 -> 1.36.0]
+- io.opentelemetry:opentelemetry-api [1.32.0 -> 1.35.0]
 
 ## Test dependency upgrades
 - org.mockito:mockito-junit-jupiter [5.10.0 -> 5.11.0]

--- a/release-notes/5.x.md
+++ b/release-notes/5.x.md
@@ -1,4 +1,4 @@
-# 5.15.3
+# 5.15.4
 
 ## Upgrade to spring-boot 3.2.4
 This includes an [upgrade to Spring Boot 3.2.4](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.4)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
@@ -4,8 +4,8 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import uk.gov.justice.digital.hmpps.gradle.ConfigManager
 
-private const val APP_INSIGHTS_VERSION = "3.4.19"
-const val OPENTELEMETRY_VERSION = "1.32.0"
+private const val APP_INSIGHTS_VERSION = "3.5.1"
+const val OPENTELEMETRY_VERSION = "1.36.0"
 
 class AppInsightsConfigManager(override val project: Project) : ConfigManager {
   override fun configure() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/configmanagers/AppInsightsConfigManager.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.Copy
 import uk.gov.justice.digital.hmpps.gradle.ConfigManager
 
 private const val APP_INSIGHTS_VERSION = "3.5.1"
-const val OPENTELEMETRY_VERSION = "1.36.0"
+const val OPENTELEMETRY_VERSION = "1.35.0"
 
 class AppInsightsConfigManager(override val project: Project) : ConfigManager {
   override fun configure() {


### PR DESCRIPTION
Upgrade to spring-boot 3.2.4:
 - This includes an [upgrade to Spring Boot 3.2.4](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.4)

Upgrade to Kotlin 1.9.23
- This includes an [upgrade to Kotlin 1.9.23](https://github.com/JetBrains/kotlin/releases/tag/v1.9.23/)

Version Upgrades:
- com.microsoft.azure:applicationinsights-agent [3.4.19 -> 3.5.1]
- com.microsoft.azure:applicationinsights-core [3.4.19 -> 3.5.1]
- io.opentelemetry:opentelemetry-api [1.32.0 -> 1.35.0]

Test dependency upgrades:
- org.mockito:mockito-junit-jupiter [5.10.0 -> 5.11.0]
- org.eclipse.jgit:org.eclipse.jgit [6.8.0.202311291450-r -> 6.9.0.202403050737-r]