### PR TITLE
Update 5.x release notes README

### DIFF
--- a/release-notes/5.x.md
+++ b/release-notes/5.x.md
@@ -563,6 +563,12 @@ Applied test dependencies:
 ## Upgrade to spring-boot 3.0.2
 This includes an [upgrade to Spring Boot 3.0.2](https://github.com/spring-projects/spring-boot/releases/tag/v3.0.2)
 
+### Upgrade to spring framework major version 6
+
+Note that as of Spring Framework 6.0, the [trailing slash matching](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes) configuration option has been deprecated and its default value set to false.
+
+> Developers should instead configure explicit redirects/rewrites through a proxy, a Servlet/web filter, or even declare the additional route explicitly on the controller handler (like @GetMapping("/some/greeting", "/some/greeting/") for more targeted cases.
+
 ## Upgrade to Kotlin 1.8.0
 This includes an [upgrade to Kotlin 1.8.0](https://github.com/JetBrains/kotlin/releases/tag/v1.8.0/)
 


### PR DESCRIPTION
Update readme to note that as of Spring Framework 6.0 trailing slash is no longer automatically matched

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes

This lead to us having 404s when upgrading to version 5.x of this.