### PR TITLE
HAAR-3622: 🔒Suppress netty-handler 4.1.118.final vulnerability as this

### DIFF
--- a/release-notes/7.x.md
+++ b/release-notes/7.x.md
@@ -11,6 +11,9 @@ From the CVE:
 > Version 4.1.118.Final contains a patch. As workaround its possible to 
 > either disable the usage of the native SSLEngine or change the code manually.
 
+Also added the supression for this as Sonartype 
+https://ossindex.sonatype.org/component/pkg:maven/io.netty/netty-handler@4.1.118.Final is reporting as vulnerable even though it isn’t. 
+
 # 7.1.0
 
 Suppression for

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -87,4 +87,11 @@
     <packageUrl regex="true">^pkg:maven/net\.minidev/json\-smart@.*$</packageUrl>
     <vulnerabilityName>CVE-2024-57699</vulnerabilityName>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: netty-handler-4.1.118.Final.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+    <vulnerabilityName>CVE-2025-24970</vulnerabilityName>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
…version contains the fix - https://nvd.nist.gov/vuln/detail/CVE-2025-24970