### PR TITLE
CPR-1161 reintroduce suppression for appinsights CVE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
   // have to not use implementation(kotlin("gradle-plugin")) syntax here otherwise useLatestVersions fails
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0")
 
-  implementation("org.springframework.boot:spring-boot-gradle-plugin:4.1.0")
+  implementation("org.springframework.boot:spring-boot-gradle-plugin:4.0.7")
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7")
   implementation("org.owasp:dependency-check-core:12.2.2")
   implementation("org.owasp:dependency-check-gradle:12.2.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 group = "uk.gov.justice.hmpps.gradle"
-version = "10.5.2"
+version = "10.5.3"
 
 gradlePlugin {
   website.set("https://github.com/ministryofjustice/hmpps-gradle-spring-boot")
@@ -53,7 +53,7 @@ dependencies {
   // have to not use implementation(kotlin("gradle-plugin")) syntax here otherwise useLatestVersions fails
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0")
 
-  implementation("org.springframework.boot:spring-boot-gradle-plugin:4.0.7")
+  implementation("org.springframework.boot:spring-boot-gradle-plugin:4.1.0")
   implementation("io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7")
   implementation("org.owasp:dependency-check-core:12.2.2")
   implementation("org.owasp:dependency-check-gradle:12.2.2")

--- a/release-notes/10.x.md
+++ b/release-notes/10.x.md
@@ -1,3 +1,9 @@
+# 10.5.3
+
+## Suppression for AppInsights false positive
+
+Reintroducing a suppression for [CVE-2025-21199](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-21199) which was removed in v10.5.1. The suppression is already there for the `applicationinsights-agent` package 
+
 # 10.5.2
 
 ## Suppression for swagger-ui / dompurify issues

--- a/src/main/resources/dps-gradle-spring-boot-suppressions.xml
+++ b/src/main/resources/dps-gradle-spring-boot-suppressions.xml
@@ -22,6 +22,14 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
+    Suppressed as falsely matching cpe:2.3:a:microsoft:azure_agent:3.7.4:*:*:*:*:*:*:*.
+    file name: applicationinsights-core-3.7.4.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/applicationinsights-core@.*$</packageUrl>
+    <cve>CVE-2025-21199</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
     Suppression for dompurify issue as only bundled with swagger-ui and swagger docs should only be available in dev.
     file name: swagger-ui-5.32.2.jar: swagger-ui-bundle.js
     ]]></notes>


### PR DESCRIPTION
Looks like this suppression was removed in this commit
https://github.com/ministryofjustice/hmpps-gradle-spring-boot/commit/254153f9c7d3e8a4f1f2649ed530eb9d4b674e77

Fixes this alert: 
https://github.com/ministryofjustice/hmpps-person-record/security/code-scanning/399

It is already suppressed here for applicationinsights-agent: https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/src/main/resources/dps-gradle-spring-boot-suppressions.xml#L15